### PR TITLE
New constructor if non-default endpoint

### DIFF
--- a/oauth/client.go
+++ b/oauth/client.go
@@ -49,7 +49,17 @@ type oauth2Response struct {
 // The client will use the httpclient's configured BaseURIs.
 func NewClientCredentialClient(client httpclient.Client) ClientCredentialClient {
 	return &serviceClient{
-		client: client,
+		client:                   client,
+		clientCredentialEndpoint: clientCredentialsEndpoint,
+	}
+}
+
+// NewClientCredentialClientWithEndpoint returns an oauth2.Client configured using the provided client and oauth endpoint.
+// The client will use the httpclient's configured BaseURIs.
+func NewClientCredentialClientWithEndpoint(client httpclient.Client, endpoint string) ClientCredentialClient {
+	return &serviceClient{
+		client:                   client,
+		clientCredentialEndpoint: endpoint,
 	}
 }
 
@@ -63,7 +73,7 @@ func (s *serviceClient) CreateClientCredentialToken(ctx context.Context, clientI
 	_, err := s.client.Do(ctx,
 		httpclient.WithRPCMethodName("CreateClientCredentialToken"),
 		httpclient.WithRequestMethod(http.MethodPost),
-		httpclient.WithPath(clientCredentialsEndpoint),
+		httpclient.WithPath(s.clientCredentialEndpoint),
 		httpclient.WithRequestBody(urlValues, codecs.FormURLEncoded),
 		httpclient.WithJSONResponse(&oauth2Resp),
 		httpclient.WithRequestErrorDecoder(errorDecoder{ctx}),


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The oauth2 `serviceClient` was always using the default endpoint of `/oauth2/token` which doesn't work for all auth providers (e.g., keycloak) and there was no mechanism to configure this endpoint within the constructor.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
* Modified the `CreateClientCredentialToken` function to leverage the `serviceClient` endpoint parameter vs only using the default value.
* Created a new constructor, `NewClientCredentialClientWithEndpoint` that takes in an additional string parameter if a non-default endpoint is desired. Did this as a new constructor to ensure we don't break existing usages of the constructor.
* Explicitly set the `serviceClient` endpoint parameter with the default value now that we're using it's value vs the file level default.

==COMMIT_MSG==
Configurable OAuth2 endpoints for ClientCredentialClient
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

