### PR TITLE
Break: Update module to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/palantir/go-oauth2-client/v2
+module github.com/palantir/go-oauth2-client/v3
 
 go 1.25.0
 

--- a/token/provider.go
+++ b/token/provider.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/palantir/conjure-go-runtime/v3/conjure-go-client/httpclient"
-	"github.com/palantir/go-oauth2-client/v2/oauth"
+	"github.com/palantir/go-oauth2-client/v3/oauth"
 )
 
 // Provider accepts a context and returns either:

--- a/token/refresher_test.go
+++ b/token/refresher_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/palantir/go-oauth2-client/v2/token"
+	"github.com/palantir/go-oauth2-client/v3/token"
 	"github.com/palantir/pkg/retry"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
## Before this PR
#466 updated the API to use CGR V3, but we need to update the module version before cutting a new V3 major version release

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update module to v3
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

