### PR TITLE
Improvement: Rename refreshInterval to tokenTTL

### DIFF
--- a/token/provider.go
+++ b/token/provider.go
@@ -31,10 +31,10 @@ type Provider = httpclient.TokenProvider
 
 // CreateAndStartRefreshingOAuthProvider returns a Provider which caches and periodically refreshes a client token.
 // When it returns, we have not yet necessarily successfully fetched a valid token.
-func CreateAndStartRefreshingOAuthProvider(ctx context.Context, client oauth.ClientCredentialClient, clientID, clientSecret string, refreshInterval time.Duration) Provider {
+func CreateAndStartRefreshingOAuthProvider(ctx context.Context, client oauth.ClientCredentialClient, clientID, clientSecret string, tokenTTL time.Duration) Provider {
 	refresher := NewRefresher(func(ctx context.Context) (string, error) {
 		return client.CreateClientCredentialToken(ctx, clientID, clientSecret)
-	}, refreshInterval)
+	}, tokenTTL)
 	go refresher.Run(ctx)
 	return refresher.Token
 }


### PR DESCRIPTION
## Before this PR
The `refreshInterval` parameter was passed directly to `NewRefresher` as `tokenTTL` - the actual refresh interval is derived internally as `tokenTTL / 2`, so the original parameter name was misleading.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Rename `refreshInterval` to `tokenTTL` in `CreateAndStartRefreshingOAuthProvider`
==COMMIT_MSG==


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

