### PR TITLE
Fix: Fix token Refresher to block until successful token acquisition

### DIFF
--- a/token/refresher.go
+++ b/token/refresher.go
@@ -24,6 +24,11 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
+// defaultInitTimeout is the maximum time Token() will block waiting for the first successful
+// token acquisition when the caller's context has no earlier deadline. Callers may override
+// this with WithInitTimeout.
+const defaultInitTimeout = 60 * time.Second
+
 // Refresher periodically updates its token via its Provider.
 // This type provides thread-safe access to an up-to-date token.
 type Refresher struct {
@@ -32,7 +37,20 @@ type Refresher struct {
 	// tokenDataInitialized represents whether a token has been successfully acquired by being a closed channel.
 	tokenDataInitialized chan struct{}
 	tokenTTL             time.Duration
+	initTimeout          time.Duration
 	tokenDataLock        sync.RWMutex
+}
+
+// RefresherOption configures a Refresher at construction time.
+type RefresherOption func(*Refresher)
+
+// WithInitTimeout overrides the maximum time Token() will block waiting for the first
+// successful token acquisition. Only applies until the first success; subsequent calls to
+// Token() return immediately with the currently stored value.
+func WithInitTimeout(d time.Duration) RefresherOption {
+	return func(r *Refresher) {
+		r.initTimeout = d
+	}
 }
 
 type tokenData struct {
@@ -45,8 +63,8 @@ type tokenData struct {
 }
 
 // NewRefresher constructs a Refresher from a Provider and a token's TTL.
-func NewRefresher(provideToken Provider, tokenTTL time.Duration) *Refresher {
-	return &Refresher{
+func NewRefresher(provideToken Provider, tokenTTL time.Duration, opts ...RefresherOption) *Refresher {
+	r := &Refresher{
 		provideToken: provideToken,
 		tokenData: tokenData{
 			token:             "",
@@ -55,11 +73,21 @@ func NewRefresher(provideToken Provider, tokenTTL time.Duration) *Refresher {
 		},
 		tokenDataInitialized: make(chan struct{}),
 		tokenTTL:             tokenTTL,
+		initTimeout:          defaultInitTimeout,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
-// Token returns the currently stored token or an error if (1) there is no token stored and an attempt to get the token has failed, or (2) the stored token is not usable.
-// This method will block until a token has been successfully acquired from the provider, or the provided context is cancelled.
+// Token returns the currently stored token or an error if (1) no token has been successfully
+// acquired before the initialization timeout elapses or the caller's context is cancelled, or
+// (2) the stored token is expired and no newer token has been acquired.
+// Prior to the first successful acquisition, this method blocks until either a token is
+// acquired, the caller's context is cancelled, or the initialization timeout (see
+// WithInitTimeout, default 60s) elapses. Once a token has been acquired, this method returns
+// immediately with the currently stored value.
 func (r *Refresher) Token(ctx context.Context) (string, error) {
 	if err := r.waitForInitialized(ctx); err != nil {
 		return "", err
@@ -92,9 +120,27 @@ func (r *Refresher) Token(ctx context.Context) (string, error) {
 }
 
 func (r *Refresher) waitForInitialized(ctx context.Context) error {
+	// Fast path: avoid creating a timer if initialization has already completed.
 	select {
-	case <-ctx.Done():
-		return werror.Wrap(ctx.Err(), "context completed while waiting for initialized")
+	case <-r.tokenDataInitialized:
+		return nil
+	default:
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, r.initTimeout)
+	defer cancel()
+
+	select {
+	case <-waitCtx.Done():
+		r.tokenDataLock.RLock()
+		lastErr := r.tokenData.tokenAcquireError
+		r.tokenDataLock.RUnlock()
+		params := werror.SafeParam("initTimeout", r.initTimeout.String())
+		if lastErr != nil {
+			return werror.Wrap(lastErr, "timed out waiting for initial token acquisition",
+				werror.SafeParam("ctxErr", waitCtx.Err().Error()), params)
+		}
+		return werror.Wrap(waitCtx.Err(), "timed out waiting for initial token acquisition", params)
 	case <-r.tokenDataInitialized:
 		return nil
 	}

--- a/token/refresher.go
+++ b/token/refresher.go
@@ -29,7 +29,7 @@ import (
 type Refresher struct {
 	provideToken Provider
 	tokenData    tokenData
-	// tokenDataInitialized represents whether a token has ever been acquired, with or without error by being a closed channel.
+	// tokenDataInitialized represents whether a token has been successfully acquired by being a closed channel.
 	tokenDataInitialized chan struct{}
 	tokenTTL             time.Duration
 	tokenDataLock        sync.RWMutex
@@ -59,7 +59,7 @@ func NewRefresher(provideToken Provider, tokenTTL time.Duration) *Refresher {
 }
 
 // Token returns the currently stored token or an error if (1) there is no token stored and an attempt to get the token has failed, or (2) the stored token is not usable.
-// This method will block until an attempt is completed to the provider to get the token (either success or fail).
+// This method will block until a token has been successfully acquired from the provider, or the provided context is cancelled.
 func (r *Refresher) Token(ctx context.Context) (string, error) {
 	if err := r.waitForInitialized(ctx); err != nil {
 		return "", err
@@ -138,6 +138,12 @@ func (r *Refresher) updateToken(token string, err error) {
 			tokenAcquiredTime: time.Now(),
 			tokenAcquireError: nil,
 		}
+		// close channel on first successful token acquisition
+		select {
+		case <-r.tokenDataInitialized:
+		default:
+			close(r.tokenDataInitialized)
+		}
 	} else {
 		newTokenData = tokenData{
 			token:             r.tokenData.token,
@@ -146,10 +152,4 @@ func (r *Refresher) updateToken(token string, err error) {
 		}
 	}
 	r.tokenData = newTokenData
-	// close channel if it is not already closed
-	select {
-	case <-r.tokenDataInitialized:
-	default:
-		close(r.tokenDataInitialized)
-	}
 }

--- a/token/refresher.go
+++ b/token/refresher.go
@@ -137,10 +137,10 @@ func (r *Refresher) waitForInitialized(ctx context.Context) error {
 		r.tokenDataLock.RUnlock()
 		params := werror.SafeParam("initTimeout", r.initTimeout.String())
 		if lastErr != nil {
-			return werror.Wrap(lastErr, "timed out waiting for initial token acquisition",
+			return werror.WrapWithContextParams(waitCtx, lastErr, "timed out waiting for initial token acquisition",
 				werror.SafeParam("ctxErr", waitCtx.Err().Error()), params)
 		}
-		return werror.Wrap(waitCtx.Err(), "timed out waiting for initial token acquisition", params)
+		return werror.WrapWithContextParams(waitCtx, waitCtx.Err(), "timed out waiting for initial token acquisition", params)
 	case <-r.tokenDataInitialized:
 		return nil
 	}

--- a/token/refresher_test.go
+++ b/token/refresher_test.go
@@ -17,6 +17,7 @@ package token_test
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -168,7 +169,7 @@ func TestRefresher_WaitsForFirstCallToSlowProvider(t *testing.T) {
 	defer cancel()
 	_, err := refresher.Token(timeoutCtx)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "context completed")
+	assert.Contains(t, err.Error(), "timed out waiting for initial token acquisition")
 	close(blockingChan)
 	token, err := refresher.Token(context.Background())
 	require.NoError(t, err)
@@ -177,7 +178,7 @@ func TestRefresher_WaitsForFirstCallToSlowProvider(t *testing.T) {
 
 func TestRefresher_ErrorsOnProviderError(t *testing.T) {
 	provideToken := func(_ context.Context) (string, error) {
-		return "", werror.Error("foo")
+		return "", werror.Error("underlying provider failure")
 	}
 
 	refresher := token.NewRefresher(provideToken, time.Second)
@@ -186,14 +187,34 @@ func TestRefresher_ErrorsOnProviderError(t *testing.T) {
 	defer cancel()
 	_, err := refresher.Token(timeoutCtx)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "context completed")
+	// Error surfaces both the init-timeout and the underlying cause.
+	require.Contains(t, err.Error(), "timed out waiting for initial token acquisition")
+	require.Contains(t, err.Error(), "underlying provider failure")
+}
+
+func TestRefresher_InitTimeoutBoundsBackgroundContext(t *testing.T) {
+	provideToken := func(_ context.Context) (string, error) {
+		return "", werror.Error("always fails")
+	}
+
+	refresher := token.NewRefresher(provideToken, time.Second, token.WithInitTimeout(50*time.Millisecond))
+	go refresher.Run(context.Background())
+
+	start := time.Now()
+	_, err := refresher.Token(context.Background())
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out waiting for initial token acquisition")
+	require.Contains(t, err.Error(), "always fails")
+	// Should return near the init timeout and not block forever
+	assert.Less(t, elapsed, 500*time.Millisecond)
 }
 
 func TestRefresher_RetriesBeforeUnblocking(t *testing.T) {
-	attempts := 0
+	var attempts atomic.Int64
 	provideToken := func(_ context.Context) (string, error) {
-		attempts++
-		if attempts <= 3 {
+		if attempts.Add(1) <= 3 {
 			return "", werror.Error("transient failure")
 		}
 		return "goodtoken", nil
@@ -206,5 +227,5 @@ func TestRefresher_RetriesBeforeUnblocking(t *testing.T) {
 	tok, err := refresher.Token(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "goodtoken", tok)
-	assert.Greater(t, attempts, 3)
+	assert.Greater(t, attempts.Load(), int64(3))
 }

--- a/token/refresher_test.go
+++ b/token/refresher_test.go
@@ -113,7 +113,7 @@ func TestRefresher_RunFailsAfterSucceeding(t *testing.T) {
 	wg.Wait()
 }
 
-// Note, this test asssumes a certain accuracy of time.Sleep that can't actually be guaranteed, while it's unlikely to
+// Note, this test assumes a certain accuracy of time.Sleep that can't actually be guaranteed, while it's unlikely to
 // fail it does add a bit of fragility in order to preserve readability
 func TestRefresher_RunSucceedsAfterFailing(t *testing.T) {
 	shouldFail := true
@@ -137,29 +137,17 @@ func TestRefresher_RunSucceedsAfterFailing(t *testing.T) {
 		refresher.Run(ctx)
 	})
 
-	// Sleep to allow at least one failed token attempt
-	time.Sleep(ttl / 4)
-	token, err := refresher.Token(context.Background())
-	assert.Equal(t, "", token)
-	assert.Error(t, err)
-	assert.True(t, hasFailed)
+	// Stop failing after a delay so the retry loop can succeed
+	wg.Go(func() {
+		time.Sleep(ttl / 4)
+		shouldFail = false
+	})
 
-	shouldFail = false
-
-	assert.NoError(t, retry.Do(ctx, func() error {
-		token, err := refresher.Token(context.Background())
-		if token != "goodtoken" {
-			return werror.Error("expected token to be 'goodtoken'")
-		}
-		if err != nil {
-			return werror.Error("expected err to be nil")
-		}
-		return nil
-	}, retry.WithMaxBackoff(10*time.Millisecond), retry.WithMaxAttempts(10)))
-
-	token, err = refresher.Token(context.Background())
-	assert.Equal(t, "goodtoken", token)
+	// Token() blocks until the first successful acquisition
+	tok, err := refresher.Token(context.Background())
+	assert.Equal(t, "goodtoken", tok)
 	assert.NoError(t, err)
+	assert.True(t, hasFailed)
 
 	cancel()
 	wg.Wait()
@@ -194,7 +182,29 @@ func TestRefresher_ErrorsOnProviderError(t *testing.T) {
 
 	refresher := token.NewRefresher(provideToken, time.Second)
 	go refresher.Run(context.Background())
-	_, err := refresher.Token(context.Background())
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := refresher.Token(timeoutCtx)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "foo")
+	require.Contains(t, err.Error(), "context completed")
+}
+
+func TestRefresher_RetriesBeforeUnblocking(t *testing.T) {
+	attempts := 0
+	provideToken := func(_ context.Context) (string, error) {
+		attempts++
+		if attempts <= 3 {
+			return "", werror.Error("transient failure")
+		}
+		return "goodtoken", nil
+	}
+
+	refresher := token.NewRefresher(provideToken, time.Second)
+	go refresher.Run(context.Background())
+
+	// Token() should block through failures and return once a retry succeeds
+	tok, err := refresher.Token(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "goodtoken", tok)
+	assert.Greater(t, attempts, 3)
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix token Refresher to block until successful token acquisition

Previously, `updateToken` closed the `tokenDataInitialized` channel on the first attempt regardless of success or failure. This meant `Token()` would unblock and return an error before `retry.Do` had a chance to retry, causing transient failures (e.g. a 503 from the token endpoint) to surface as hard errors during initialization. The channel is now only closed on successful token acquisition, so `Token()` blocks until a valid token is obtained, the caller's context is cancelled, or an initialization timeout of 60s is reached.
==COMMIT_MSG==

This is a behavioral change for any transient or persistent startup failure, but once a token has been acquired the behavior remains the same. For transient startup errors `Token()` will block through failures and eventually unblocks once retries succeed. Permanent failures will now block indefinitely until the context is cancelled. In practice, most usages of the `TokenProvider` are called through `conjure-go-runtime` HTTP clients which pass a `req.Context()` with a default HTTP timeout of 60s in the authTokenMiddleware ([code](https://github.com/palantir/conjure-go-runtime/blob/34124fe5c407916b2d9f69c89be461fa82414eb8/conjure-go-client/httpclient/authn.go#L42)) - meaning the `Token()` call will only block for the HTTP request timeout period if there were no successful retrievals.

The main risk would be for any usages of `Token()` outside of a CGR HTTP client since this will now rely on the user passing a context that can be cancelled.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

